### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the correct order

### DIFF
--- a/easymvp/src/main/java/com/example/zane/easymvp/view/BaseListViewHolderImpl.java
+++ b/easymvp/src/main/java/com/example/zane/easymvp/view/BaseListViewHolderImpl.java
@@ -40,11 +40,11 @@ public abstract class BaseListViewHolderImpl<M> extends RecyclerView.ViewHolder{
 
     public abstract void setData(M data);
 
-    final protected <T extends View> T $(@IdRes int id) {
+    protected final <T extends View> T $(@IdRes int id) {
         return (T) view.findViewById(id);
     }
 
-    final public <T extends View> T bindView(int id) {
+    public final <T extends View> T bindView(int id) {
         T view2 = (T) mViews.get(id);
         if (view2 == null) {
             view2 = $(id);
@@ -53,7 +53,7 @@ public abstract class BaseListViewHolderImpl<M> extends RecyclerView.ViewHolder{
         return view2;
     }
 
-    final public <T extends View> T get(int id) {
+    public final <T extends View> T get(int id) {
         return (T) bindView(id);
     }
 

--- a/easymvp/src/main/java/com/example/zane/easymvp/view/BaseViewImpl.java
+++ b/easymvp/src/main/java/com/example/zane/easymvp/view/BaseViewImpl.java
@@ -25,7 +25,7 @@ public abstract class BaseViewImpl implements IView{
     protected final SparseArray<View> mViews = new SparseArray<View>();
 
     @Override
-    final public void creatView(LayoutInflater inflater, ViewGroup parent, Bundle bundle) {
+    public final void creatView(LayoutInflater inflater, ViewGroup parent, Bundle bundle) {
         int resourceId = getRootViewId();
 
         if (resourceId == 0){
@@ -36,7 +36,7 @@ public abstract class BaseViewImpl implements IView{
     }
 
     @Override
-    final public View getRootView() {
+    public final View getRootView() {
         return view;
     }
 
@@ -45,19 +45,19 @@ public abstract class BaseViewImpl implements IView{
 
     //添加注解view方式
     @Override
-    final public void initView() {
+    public final void initView() {
         ButterKnife.bind(this, view);
     }
 
     @Override
-    final public void removeView() {
+    public final void removeView() {
         ButterKnife.unbind(this);
     }
 
     @Override
     public abstract void setActivityContext(Activity activity);
 
-    final public <T extends View> T bindView(int id) {
+    public final <T extends View> T bindView(int id) {
         T view2 = (T) mViews.get(id);
         if (view2 == null) {
             view2 = $(id);
@@ -66,16 +66,16 @@ public abstract class BaseViewImpl implements IView{
         return view2;
     }
 
-    final public <T extends View> T get(int id) {
+    public final <T extends View> T get(int id) {
         return (T) bindView(id);
     }
 
-    final protected <T extends View> T $(@IdRes int id) {
+    protected final <T extends View> T $(@IdRes int id) {
         return (T) view.findViewById(id);
     }
 
 
-    final public void setOnClickListener(View.OnClickListener listener, int... ids) {
+    public final void setOnClickListener(View.OnClickListener listener, int... ids) {
         if (ids == null) {
             return;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Ayman Abdelghany.
