### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/demo/src/main/java/com/example/zane/demo/presenter/MainActivity.java
+++ b/demo/src/main/java/com/example/zane/demo/presenter/MainActivity.java
@@ -89,7 +89,7 @@ public class MainActivity extends BaseActivityPresenter<MainListView>{
     private final class MyHandler extends Handler{
         WeakReference<MainActivity> reference;
         public MyHandler(MainActivity activity){
-            reference = new WeakReference<MainActivity>(activity);
+            reference = new WeakReference<>(activity);
         }
 
         @Override

--- a/easymvp/src/main/java/com/example/zane/easymvp/view/BaseListViewHolderImpl.java
+++ b/easymvp/src/main/java/com/example/zane/easymvp/view/BaseListViewHolderImpl.java
@@ -21,7 +21,7 @@ import butterknife.ButterKnife;
 public abstract class BaseListViewHolderImpl<M> extends RecyclerView.ViewHolder{
 
     protected View view;
-    protected final SparseArray<View> mViews = new SparseArray<View>();
+    protected final SparseArray<View> mViews = new SparseArray<>();
 
     public BaseListViewHolderImpl(View itemView) {
         super(itemView);

--- a/easymvp/src/main/java/com/example/zane/easymvp/view/BaseViewImpl.java
+++ b/easymvp/src/main/java/com/example/zane/easymvp/view/BaseViewImpl.java
@@ -22,7 +22,7 @@ import butterknife.ButterKnife;
 public abstract class BaseViewImpl implements IView{
 
     protected View view;
-    protected final SparseArray<View> mViews = new SparseArray<View>();
+    protected final SparseArray<View> mViews = new SparseArray<>();
 
     @Override
     final public void creatView(LayoutInflater inflater, ViewGroup parent, Bundle bundle) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.
